### PR TITLE
including app.js relative to root for players sub pages

### DIFF
--- a/02-router/src/index.html
+++ b/02-router/src/index.html
@@ -25,6 +25,6 @@
   </div>
 </div>
 <script src="//localhost:35729/livereload.js"></script>
-<script src="app.js"></script>
+<script src="/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
getting an error when calling `players/:player` directly
`<script src="app.js"></script>` should be replaced with `<script src="/app.js"></script>`

![](http://tclhost.com/Au786HZ.gif)